### PR TITLE
website: additional rebrand changes

### DIFF
--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -10,7 +10,7 @@ describe('workspace-project App', () => {
 
   it('should display welcome message', () => {
     page.navigateTo();
-    expect(page.getTitleText()).toEqual('Welcome to runeliteplus!');
+    expect(page.getTitleText()).toEqual('Welcome to openosrs!');
   });
 
   afterEach(async () => {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "runeliteplus",
+  "name": "openosrs",
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",

--- a/src/app/components/content/app-downloads/downloads.component.ts
+++ b/src/app/components/content/app-downloads/downloads.component.ts
@@ -25,33 +25,33 @@ export class AppDownloadsComponent implements OnInit {
     [
       'E1CDDAF65C11813B14C854D8ADE67CCA',
       'A97064827688FEDFFD1728EC977DF32BE160077B',
-      `https://github.com/runelite-extended/launcher/releases/download/${this.version}/OpenOSRSSetup64.exe`
+      `https://github.com/open-osrs/launcher/releases/download/${this.version}/OpenOSRSSetup64.exe`
     ],
 
     // Windows x32; md5, sha1
     [
       '9F69B09CCA7151A2E4389A5F8A226E8F',
       'D12C3743B72E043026656C2984386EB1E1FB939F',
-      `https://github.com/runelite-extended/launcher/releases/download/${this.version}/OpenOSRSSetup32.exe`
+      `https://github.com/open-osrs/launcher/releases/download/${this.version}/OpenOSRSSetup32.exe`
     ],
     // MacOS; md5, sha1
     [
       '3BBF416DBB817607C6CFC184DDFC6451',
       '04A0558BE06264E8AB078657E9F1AADE966F47D7',
-      `https://github.com/runelite-extended/launcher/releases/download/${this.version}/OpenOSRSSetup.dmg`],
+      `https://github.com/open-osrs/launcher/releases/download/${this.version}/OpenOSRSSetup.dmg`],
 
     // Linux; md5, sha1
     [
       'F9F9096AFBF0E4B5A5233713D927CD70',
       'DF73B1C16506D3FC7FF8B1948800875B35B78B60',
-      `https://github.com/runelite-extended/launcher/releases/download/${this.version}/OpenOSRS.AppImage`
+      `https://github.com/open-osrs/launcher/releases/download/${this.version}/OpenOSRS.AppImage`
     ],
 
     // Jar; md5, sha1
     [
       'BDA49C77262CB61C81ACA88282EA638C',
       '3031D49F95E37E6E18DC19ABE1F26C2798DF7BA4',
-      `https://github.com/runelite-extended/launcher/releases/download/${this.version}/OpenOSRS.jar`
+      `https://github.com/open-osrs/launcher/releases/download/${this.version}/OpenOSRS.jar`
     ]
   ];
 
@@ -68,7 +68,7 @@ export class AppDownloadsComponent implements OnInit {
     this.metaService.updateTags([
       {
         name: 'keywords',
-        content: 'runelite, runeliteplus, runelite plus, runelite pvp plugins, runelite pvp, runelite plugins, download, downloads'
+        content: 'openosrs, open osrs, runelite, runeliteplus, runelite plus, runelite pvp plugins, runelite pvp, runelite plugins, download, downloads'
       },
       { name: 'description', content: description },
       { name: 'twitter:description', content: description },

--- a/src/app/components/content/app-features/features.component.ts
+++ b/src/app/components/content/app-features/features.component.ts
@@ -41,7 +41,7 @@ export class AppFeaturesComponent implements OnInit {
     this.metaService.updateTags([
       {
         name: 'keywords',
-        content: 'runelite, runeliteplus, runelite plus, runelite pvp plugins, runelite pvp, runelite plugins, zulrah, vorkath'
+        content: 'openosrs, open osrs, runelite, runeliteplus, runelite plus, runelite pvp plugins, runelite pvp, runelite plugins, zulrah, vorkath'
       },
       { name: 'description', content: description },
       { name: 'twitter:description', content: description },

--- a/src/app/components/content/app-home/home.component.html
+++ b/src/app/components/content/app-home/home.component.html
@@ -45,7 +45,7 @@
               </mat-card-content>
               <mat-card-actions>
                 <a mat-raised-button="mat-raised-button" color="primary" target="_blank" rel="noopener noreferrer"
-                  href="https://github.com/runelite-extended/runelite/wiki/Plugin-Support">
+                  href="https://github.com/open-osrs/runelite/wiki/Plugin-Support">
                   Read more
                 </a>
               </mat-card-actions>
@@ -65,7 +65,7 @@
               </mat-card-content>
               <mat-card-actions>
                 <a mat-raised-button="mat-raised-button" color="primary" target="_blank" rel="noopener noreferrer"
-                  href="https://github.com/runelite-extended/runelite">
+                  href="https://github.com/open-osrs/runelite">
                   View OPRS Source
                 </a>
               </mat-card-actions>

--- a/src/app/components/content/app-home/home.component.ts
+++ b/src/app/components/content/app-home/home.component.ts
@@ -40,7 +40,7 @@ export class AppHomeComponent implements OnInit {
     const description = 'Open-source client for Old School RuneScape with more functionality and less restrictions.';
 
     this.metaService.updateTags([
-      { name: 'keywords', content: 'runelite, runeliteplus, runelite plus, runelite pvp plugins, runelite pvp, runelite plugins' },
+      { name: 'keywords', content: 'openosrs, open osrs, runelite, runeliteplus, runelite plus, runelite pvp plugins, runelite pvp, runelite plugins' },
       { name: 'description', content: description },
       { name: 'twitter:description', content: description },
       { name: 'og:url', content: 'https://openosrs.com/home', property: true },

--- a/src/app/components/content/app-updates/updates.component.html
+++ b/src/app/components/content/app-updates/updates.component.html
@@ -40,7 +40,7 @@
                 Full page
               </a>
               <a mat-raised-button="mat-raised-button" color="primary" target="_blank" rel="noopener noreferrer"
-                [attr.href]="'https://github.com/runelite-extended/runelitepl.us/blob/master/src/assets/posts/' + update.mdFile + '.md'">
+                [attr.href]="'https://github.com/open-osrs/runelitepl.us/blob/master/src/assets/posts/' + update.mdFile + '.md'">
                 Edit on github
               </a>
             </mat-action-row>

--- a/src/app/components/content/app-updates/updates.component.html
+++ b/src/app/components/content/app-updates/updates.component.html
@@ -40,7 +40,7 @@
                 Full page
               </a>
               <a mat-raised-button="mat-raised-button" color="primary" target="_blank" rel="noopener noreferrer"
-                [attr.href]="'https://github.com/open-osrs/runelitepl.us/blob/master/src/assets/posts/' + update.mdFile + '.md'">
+                [attr.href]="'https://github.com/open-osrs/openosrs.com/blob/master/src/assets/posts/' + update.mdFile + '.md'">
                 Edit on github
               </a>
             </mat-action-row>

--- a/src/app/components/layout/app-header/header.component.html
+++ b/src/app/components/layout/app-header/header.component.html
@@ -1,7 +1,7 @@
 <mat-toolbar class="header" color="primary">
   <mat-toolbar-row>
     <a class="title" routerLink="/home">
-      <img class="logo" src="/assets/icons/icon-32x32.png" alt="RunelitePlus" height="23" width="23" />
+      <img class="logo" src="/assets/icons/icon-32x32.png" alt="OpenOSRS" height="23" width="23" />
       <span>
         OpenOSRS
       </span>
@@ -18,11 +18,11 @@
       <mat-icon class="icon" aria-hidden="false" aria-label="Discord" svgIcon="discord"></mat-icon>
     </a>
     <a mat-icon-button="mat-icon-button" target="_blank" rel="noopener noreferrer"
-      href="https://twitter.com/runeliteplus">
+      href="https://twitter.com/OpenOSRS">
       <mat-icon class="icon" aria-hidden="false" aria-label="Twitter" svgIcon="twitter"></mat-icon>
     </a>
     <a mat-icon-button="mat-icon-button" target="_blank" rel="noopener noreferrer"
-      href="https://github.com/runelite-extended">
+      href="https://github.com/open-osrs">
       <mat-icon class="icon" aria-hidden="false" aria-label="Github" svgIcon="github"></mat-icon>
     </a>
     <a mat-icon-button="mat-icon-button" target="_blank" rel="noopener noreferrer"

--- a/src/app/components/layout/app-header/header.component.html
+++ b/src/app/components/layout/app-header/header.component.html
@@ -26,7 +26,7 @@
       <mat-icon class="icon" aria-hidden="false" aria-label="Github" svgIcon="github"></mat-icon>
     </a>
     <a mat-icon-button="mat-icon-button" target="_blank" rel="noopener noreferrer"
-      href="https://www.patreon.com/join/RuneLitePlus">
+      href="https://www.patreon.com/join/OpenOSRS">
       <mat-icon class="icon" aria-hidden="false" aria-label="Patreon" svgIcon="patreon" color="accent"></mat-icon>
     </a>
   </mat-toolbar-row>

--- a/src/app/services/github.service.ts
+++ b/src/app/services/github.service.ts
@@ -17,7 +17,7 @@ import { take } from 'rxjs/operators';
 export class GithubService {
 
   private baseUrlApi = 'https://api.github.com';
-  private user = 'runelite-extended';
+  private user = 'open-osrs';
   private repository = 'runelite';
 
   private db = new NgxIndexedDB('runelite-plus', 1);

--- a/src/assets/plugins/plugins.json
+++ b/src/assets/plugins/plugins.json
@@ -12,7 +12,7 @@
     "name": "Account Switcher",
     "image": "account-switcher",
     "description": "This will allow you to switch between accounts at the hit of a button.",
-    "wiki": "https://github.com/runelite-extended/runelite/wiki/Account-Switcher",
+    "wiki": "https://github.com/open-osrs/runelite/wiki/Account-Switcher",
     "categories": [
       "Utility"
     ]
@@ -37,7 +37,7 @@
     "name": "AoE Warnings",
     "image": "aoe-warnings",
     "description": "This will show you the projectiles of certain enemy attacks.",
-    "wiki": "https://github.com/runelite-extended/runelite/wiki/Aoe-Warnings",
+    "wiki": "https://github.com/open-osrs/runelite/wiki/Aoe-Warnings",
     "categories": [
       "PvM"
     ]
@@ -46,7 +46,7 @@
     "name": "Barbarian Assault+",
     "image": "barbarian-assault-plus",
     "description": "Custom barbarian assault plugin, highlight eggs and a lot more.",
-    "wiki": "https://github.com/runelite-extended/runelite/wiki/Barbarian-Assault-",
+    "wiki": "https://github.com/open-osrs/runelite/wiki/Barbarian-Assault-",
     "categories": [
       "PvM"
     ]
@@ -55,7 +55,7 @@
     "name": "Chambers of Xeric",
     "image": "chambers-of-xeric",
     "description": "Tick Timer for Olm, Overlays for all special attacks, and Olm Prayer Helper showing you what to pray.",
-    "wiki": "https://github.com/runelite-extended/runelite/wiki/CoX-Helper",
+    "wiki": "https://github.com/open-osrs/runelite/wiki/CoX-Helper",
     "categories": [
       "PvM"
     ]
@@ -320,7 +320,7 @@
     "name": "Supplies Used Tracker",
     "image": "supplies-used-tracker",
     "description": "Track your supplies while pvping or pvming, very useful.",
-    "wiki": "https://github.com/runelite-extended/runelite/wiki/Supplies-tracker",
+    "wiki": "https://github.com/open-osrs/runelite/wiki/Supplies-tracker",
     "categories": [
       "Utility",
       "PvP",
@@ -403,7 +403,7 @@
     "name": "Zulrah Helper",
     "image": "zulrah-helper",
     "description": "Kill Zulrah no problem with our zulrah helper. Raise that KC!",
-    "wiki": "https://github.com/runelite-extended/runelite/wiki",
+    "wiki": "https://github.com/open-osrs/runelite/wiki",
     "categories": [
       "PvM"
     ]

--- a/src/assets/posts/openosrs-update-1.4.md
+++ b/src/assets/posts/openosrs-update-1.4.md
@@ -10,7 +10,7 @@
 - Scammer list Added to highlight in CC and trade chat if they are a known scammer. uses lists from We do Raids, WDR, RuneWatch.
 - Freeze timers have been fixed.
 - FPS Slider bar has been adjusted to allow you to go down to 1 FPS, previous limit was 10 FPS Minimum.
-- [Chamber of Xerics](https://github.com/runelite-extended/runelite/wiki/CoX-Helper) has been re-worked to work with the reduced functionality client.
+- [Chamber of Xerics](https://github.com/open-osrs/runelite/wiki/CoX-Helper) has been re-worked to work with the reduced functionality client.
 - Added ability to automatically screenshot friend and cc deaths.
 - Debugging has been removed from certain plugins to reduce console spam.
 - Added custom client updatecheck mode to easily load from file
@@ -24,7 +24,7 @@
 - XP Drop plugin has been fixed to show you the hit next to the XP Drop, this will no longer error upon enabling the plugin.
 - Theiving plugin has been re-worked to not trigger farming patches (oops!).
 - Fixed a flicker caused by a string option having multiple lines in config.
-- [Hydra](https://github.com/runelite-extended/runelite/wiki/Alchemical-Hydra) has been fixed and now works as expected.
+- [Hydra](https://github.com/open-osrs/runelite/wiki/Alchemical-Hydra) has been fixed and now works as expected.
 - Null point exception error fixed when entering the crypt at barrows.
 - Added an option for hiding certain tooltips to the mouse highlight plugin.
 - COX had a complete overhaul on the config, allowing for greater customization. it has also had many, many bug fixes. Additional features have been added to, these include: Tekton Tick Tracker, Vanguards Highlight Overlay and HP Counter, and Olm Teleport Targets and Solo Targets (huge shoutout to Ganom on this one).

--- a/src/assets/posts/openosrs-update-2.1.3.0.md
+++ b/src/assets/posts/openosrs-update-2.1.3.0.md
@@ -4,241 +4,241 @@
 ## OpenOSRS 2.1.3.0
 
 ##### [Crystalknoct](https://github.com/Crystalknoct)
-* [damagecounter](https://github.com/runelite-extended/runelite/pull/1307): updated grammar
-* [itemvariations](https://github.com/runelite-extended/runelite/pull/1229): added SOTE items
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1251): fixed max cape swap
+* [damagecounter](https://github.com/open-osrs/runelite/pull/1307): updated grammar
+* [itemvariations](https://github.com/open-osrs/runelite/pull/1229): added SOTE items
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1251): fixed max cape swap
 
 ##### [Ganom](https://github.com/Ganom)
-* [blackjack](https://github.com/runelite-extended/runelite/pull/1265): Swap blackjack back to priority system.
-* [config](https://github.com/runelite-extended/runelite/pull/1262): Change slider to white, so its easier to see.
-* [coxhelper](https://github.com/runelite-extended/runelite/pull/1295): add scaling to infobox
-* [events](https://github.com/runelite-extended/runelite/pull/1214): reduce projectilemoved usage as much as possible
-* [flexo](https://github.com/runelite-extended/runelite/pull/1345): add back in core class, until (#1315) is resolved.
-* [gauntlet](https://github.com/runelite-extended/runelite/pull/1246): various updates
-* [launcher](https://github.com/runelite-extended/runelite/pull/1321): make it a lil bit prettier.
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1190): move menuentryadded swaps to priority
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1263): Fix various bugs, set priorities, and more.
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1281): Fix birdhouse priority entries.
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1326): fix assignment being lower priority than trade.
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1327): add equipment swaps, and use them to fix swaps.
-* [playerscouter](https://github.com/runelite-extended/runelite/pull/1294): fix conmod exception, and various other updates.
-* [pluginsorter](https://github.com/runelite-extended/runelite/pull/1282): Fix Alpha
-* [runeliteplus](https://github.com/runelite-extended/runelite/pull/1331): add detach cam toggle
-* [theatre](https://github.com/runelite-extended/runelite/pull/1264): Fix sote projectiles.
+* [blackjack](https://github.com/open-osrs/runelite/pull/1265): Swap blackjack back to priority system.
+* [config](https://github.com/open-osrs/runelite/pull/1262): Change slider to white, so its easier to see.
+* [coxhelper](https://github.com/open-osrs/runelite/pull/1295): add scaling to infobox
+* [events](https://github.com/open-osrs/runelite/pull/1214): reduce projectilemoved usage as much as possible
+* [flexo](https://github.com/open-osrs/runelite/pull/1345): add back in core class, until (#1315) is resolved.
+* [gauntlet](https://github.com/open-osrs/runelite/pull/1246): various updates
+* [launcher](https://github.com/open-osrs/runelite/pull/1321): make it a lil bit prettier.
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1190): move menuentryadded swaps to priority
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1263): Fix various bugs, set priorities, and more.
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1281): Fix birdhouse priority entries.
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1326): fix assignment being lower priority than trade.
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1327): add equipment swaps, and use them to fix swaps.
+* [playerscouter](https://github.com/open-osrs/runelite/pull/1294): fix conmod exception, and various other updates.
+* [pluginsorter](https://github.com/open-osrs/runelite/pull/1282): Fix Alpha
+* [runeliteplus](https://github.com/open-osrs/runelite/pull/1331): add detach cam toggle
+* [theatre](https://github.com/open-osrs/runelite/pull/1264): Fix sote projectiles.
 
 ##### [Gazivodag](https://github.com/Gazivodag)
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1297):remove looting bag destroy option
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1297):remove looting bag destroy option
 
 ##### [HSJ-OSRS](https://github.com/HSJ-OSRS)
-* [cox scouter](https://github.com/runelite-extended/runelite/pull/1226): fix layout message
-* [coxhelper](https://github.com/runelite-extended/runelite/pull/1244): small code cleanup
-* [loottracker](https://github.com/runelite-extended/runelite/pull/1274): fix clue kc matching
-* [raidsthieving](https://github.com/runelite-extended/runelite/pull/1243): update and fix
-* [raidsthieving](https://github.com/runelite-extended/runelite/pull/1259): ignore room rotation
-* [screenshot](https://github.com/runelite-extended/runelite/pull/1245): use playerdeath events
+* [cox scouter](https://github.com/open-osrs/runelite/pull/1226): fix layout message
+* [coxhelper](https://github.com/open-osrs/runelite/pull/1244): small code cleanup
+* [loottracker](https://github.com/open-osrs/runelite/pull/1274): fix clue kc matching
+* [raidsthieving](https://github.com/open-osrs/runelite/pull/1243): update and fix
+* [raidsthieving](https://github.com/open-osrs/runelite/pull/1259): ignore room rotation
+* [screenshot](https://github.com/open-osrs/runelite/pull/1245): use playerdeath events
 
 ##### [Judaxx](https://github.com/Judaxx)
-* [kingdomofmiscellania](https://github.com/runelite-extended/runelite/pull/1324): add login chat notification for favor and coffer amount
+* [kingdomofmiscellania](https://github.com/open-osrs/runelite/pull/1324): add login chat notification for favor and coffer amount
 
 ##### [Kyleeld](https://github.com/Kyleeld)
-* [account](https://github.com/runelite-extended/runelite/pull/1335): remove login button
-* [bankedxp](https://github.com/runelite-extended/runelite/pull/1225): Fix Wyrm bones
-* [banktags](https://github.com/runelite-extended/runelite/pull/1336): search for valued items
-* [gauntlet](https://github.com/runelite-extended/runelite/pull/1246): various updates
-* [pluginsorter](https://github.com/runelite-extended/runelite/pull/1255): pastel colorscheme
-* [pluginsorter](https://github.com/runelite-extended/runelite/pull/1352): fix top entries
+* [account](https://github.com/open-osrs/runelite/pull/1335): remove login button
+* [bankedxp](https://github.com/open-osrs/runelite/pull/1225): Fix Wyrm bones
+* [banktags](https://github.com/open-osrs/runelite/pull/1336): search for valued items
+* [gauntlet](https://github.com/open-osrs/runelite/pull/1246): various updates
+* [pluginsorter](https://github.com/open-osrs/runelite/pull/1255): pastel colorscheme
+* [pluginsorter](https://github.com/open-osrs/runelite/pull/1352): fix top entries
 
 ##### [Lucwousin](https://github.com/Lucwousin)
-* [menumanager](https://github.com/runelite-extended/runelite/pull/1261): various fixes
-* [menumanager](https://github.com/runelite-extended/runelite/pull/1268): Make comparable entries abstract for more specific .matches()'s
-* [menumanager](https://github.com/runelite-extended/runelite/pull/1275): reuse perfectly fine Matcher instances
-* [menumanager](https://github.com/runelite-extended/runelite/pull/1283): Lowercase strings
-* [rs-client](https://github.com/runelite-extended/runelite/pull/1236): Refactoring (also gradle compiler args)
-* [rs-client](https://github.com/runelite-extended/runelite/pull/1258): Fix project for deob test
+* [menumanager](https://github.com/open-osrs/runelite/pull/1261): various fixes
+* [menumanager](https://github.com/open-osrs/runelite/pull/1268): Make comparable entries abstract for more specific .matches()'s
+* [menumanager](https://github.com/open-osrs/runelite/pull/1275): reuse perfectly fine Matcher instances
+* [menumanager](https://github.com/open-osrs/runelite/pull/1283): Lowercase strings
+* [rs-client](https://github.com/open-osrs/runelite/pull/1236): Refactoring (also gradle compiler args)
+* [rs-client](https://github.com/open-osrs/runelite/pull/1258): Fix project for deob test
 
 ##### [Netami1](https://github.com/Netami1)
-* [freezetimers](https://github.com/runelite-extended/runelite/pull/1349): fix concurrent modification exception
-* [npcunaggroarea](https://github.com/runelite-extended/runelite/pull/1350): Local Player NPE Fix
+* [freezetimers](https://github.com/open-osrs/runelite/pull/1349): fix concurrent modification exception
+* [npcunaggroarea](https://github.com/open-osrs/runelite/pull/1350): Local Player NPE Fix
 
 ##### [Owain94](https://github.com/Owain94)
-* [barrows](https://github.com/runelite-extended/runelite/pull/1337): Remove chest value option
-* [client-api](https://github.com/runelite-extended/runelite/pull/1298): fix runscript
-* [client](https://github.com/runelite-extended/runelite/pull/1269): Remove images that were used for presence switching
-* [client](https://github.com/runelite-extended/runelite/pull/1300): Fix bring client to front
-* [config](https://github.com/runelite-extended/runelite/pull/1253): Fix size issue on sliders
-* [config](https://github.com/runelite-extended/runelite/pull/1317): Save textareas on debounce instead of on focus lost
-* [gradle](https://github.com/runelite-extended/runelite/pull/1316): Update deps, format files
-* [gradle](https://github.com/runelite-extended/runelite/pull/1347): Update to gradle 5.6
-* [idlenotifier](https://github.com/runelite-extended/runelite/pull/1299): Refactor switch fallthrough and abstractions
-* [lootrecordwriter](https://github.com/runelite-extended/runelite/pull/1239): Fix reading appended objects with new GSON version
-* [project](https://github.com/runelite-extended/runelite/pull/1348): Add wiki scraper
-* [statusorbs](https://github.com/runelite-extended/runelite/pull/1237): Remove migrate code
-* [stonedloottracker](https://github.com/runelite-extended/runelite/pull/1248): Added missing bosses, skilling bosses and chests
-* [timetracking](https://github.com/runelite-extended/runelite/pull/1301): Use localized time format
-* [wiki-scraper/cache](https://github.com/runelite-extended/runelite/pull/1351): Fix NPE
-* [xptracker](https://github.com/runelite-extended/runelite/pull/1340): Fix adding skill to canvas from skill tab
+* [barrows](https://github.com/open-osrs/runelite/pull/1337): Remove chest value option
+* [client-api](https://github.com/open-osrs/runelite/pull/1298): fix runscript
+* [client](https://github.com/open-osrs/runelite/pull/1269): Remove images that were used for presence switching
+* [client](https://github.com/open-osrs/runelite/pull/1300): Fix bring client to front
+* [config](https://github.com/open-osrs/runelite/pull/1253): Fix size issue on sliders
+* [config](https://github.com/open-osrs/runelite/pull/1317): Save textareas on debounce instead of on focus lost
+* [gradle](https://github.com/open-osrs/runelite/pull/1316): Update deps, format files
+* [gradle](https://github.com/open-osrs/runelite/pull/1347): Update to gradle 5.6
+* [idlenotifier](https://github.com/open-osrs/runelite/pull/1299): Refactor switch fallthrough and abstractions
+* [lootrecordwriter](https://github.com/open-osrs/runelite/pull/1239): Fix reading appended objects with new GSON version
+* [project](https://github.com/open-osrs/runelite/pull/1348): Add wiki scraper
+* [statusorbs](https://github.com/open-osrs/runelite/pull/1237): Remove migrate code
+* [stonedloottracker](https://github.com/open-osrs/runelite/pull/1248): Added missing bosses, skilling bosses and chests
+* [timetracking](https://github.com/open-osrs/runelite/pull/1301): Use localized time format
+* [wiki-scraper/cache](https://github.com/open-osrs/runelite/pull/1351): Fix NPE
+* [xptracker](https://github.com/open-osrs/runelite/pull/1340): Fix adding skill to canvas from skill tab
 
 ##### [Pklite](https://github.com/Pklite)
-* [multilines](https://github.com/runelite-extended/runelite/pull/1272): fix bug that caused lag/fps spikes after leaving client open and hopping lots of worlds
-* [profilespanel](https://github.com/runelite-extended/runelite/pull/1332): fix panel switching
+* [multilines](https://github.com/open-osrs/runelite/pull/1272): fix bug that caused lag/fps spikes after leaving client open and hopping lots of worlds
+* [profilespanel](https://github.com/open-osrs/runelite/pull/1332): fix panel switching
 
 ##### [ReeeMan](https://github.com/ReeeMan)
-* [theatre](https://github.com/runelite-extended/runelite/pull/1310): Fix Sotes Big balls
-* [theatre](https://github.com/runelite-extended/runelite/pull/1304): remove unnecessary reset.
+* [theatre](https://github.com/open-osrs/runelite/pull/1310): Fix Sotes Big balls
+* [theatre](https://github.com/open-osrs/runelite/pull/1304): remove unnecessary reset.
 
 ##### [SRLJustin](https://github.com/SRLJustin)
-* [customcursor](https://github.com/runelite-extended/runelite/pull/1330): add skill specs as a cursor
-* [tearsofguthix](https://github.com/runelite-extended/runelite/pull/1333): fix npe
+* [customcursor](https://github.com/open-osrs/runelite/pull/1330): add skill specs as a cursor
+* [tearsofguthix](https://github.com/open-osrs/runelite/pull/1333): fix npe
 
 ##### [Sunha7](https://github.com/Sunha7)
-* [raidsshortcuts](https://github.com/runelite-extended/runelite/pull/1314): Add PVM plugintype to plugin
+* [raidsshortcuts](https://github.com/open-osrs/runelite/pull/1314): Add PVM plugintype to plugin
 
 ##### [ThatGamerBlue](https://github.com/ThatGamerBlue)
-* [client](https://github.com/runelite-extended/runelite/pull/1257): fix and enable tests
-* [client](https://github.com/runelite-extended/runelite/pull/1302): remove flexo for splitting
-* [gradle](https://github.com/runelite-extended/runelite/pull/1220): add upload task
-* [gradle](https://github.com/runelite-extended/runelite/pull/1287): update env vars to use underscores
-* [gradle](https://github.com/runelite-extended/runelite/pull/1309): fix "repository not found"
-* [httpapi](https://github.com/runelite-extended/runelite/pull/1233): fix rlp api using the wrong url
-* [rs-client](https://github.com/runelite-extended/runelite/pull/1290): fix injector getting confused with two menuAction methods
+* [client](https://github.com/open-osrs/runelite/pull/1257): fix and enable tests
+* [client](https://github.com/open-osrs/runelite/pull/1302): remove flexo for splitting
+* [gradle](https://github.com/open-osrs/runelite/pull/1220): add upload task
+* [gradle](https://github.com/open-osrs/runelite/pull/1287): update env vars to use underscores
+* [gradle](https://github.com/open-osrs/runelite/pull/1309): fix "repository not found"
+* [httpapi](https://github.com/open-osrs/runelite/pull/1233): fix rlp api using the wrong url
+* [rs-client](https://github.com/open-osrs/runelite/pull/1290): fix injector getting confused with two menuAction methods
 
 ##### [Tomcylke](https://github.com/Tomcylke)
-* [clientui](https://github.com/runelite-extended/runelite/pull/1341): fix typo
-* [itemcharges](https://github.com/runelite-extended/runelite/pull/1342): Add sacks of vegetables
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1242): Prevent Left Click Configure Shift-Click
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1270): Fix Swaps for Coal Bag
-* [slayer](https://github.com/runelite-extended/runelite/pull/1249): Font Fix
+* [clientui](https://github.com/open-osrs/runelite/pull/1341): fix typo
+* [itemcharges](https://github.com/open-osrs/runelite/pull/1342): Add sacks of vegetables
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1242): Prevent Left Click Configure Shift-Click
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1270): Fix Swaps for Coal Bag
+* [slayer](https://github.com/open-osrs/runelite/pull/1249): Font Fix
 
 ##### [Tyhi](https://github.com/Tyhi)
-* [fightcaves](https://github.com/runelite-extended/runelite/pull/1271): Fix typo
+* [fightcaves](https://github.com/open-osrs/runelite/pull/1271): Fix typo
 
 ##### [Zeruth](https://github.com/Zeruth)
-* [bootstrapper](https://github.com/runelite-extended/runelite/pull/1311): remove
-* [grounditems](https://github.com/runelite-extended/runelite/pull/1303): lighten default highlight color
-* [privateserver](https://github.com/runelite-extended/runelite/pull/1266): fix local codebase calls
+* [bootstrapper](https://github.com/open-osrs/runelite/pull/1311): remove
+* [grounditems](https://github.com/open-osrs/runelite/pull/1303): lighten default highlight color
+* [privateserver](https://github.com/open-osrs/runelite/pull/1266): fix local codebase calls
 
 ## RuneLite 1.5.31
 
 ##### [Adam-](https://github.com/Adam-):
-* [slayer plugin](https://github.com/runelite-extended/runelite/commit/715c7a26b903016f6dce0d7fe6bef9448051a615): validate !task name and location
-* [slayer plugin](https://github.com/runelite-extended/runelite/commit/08fed6dba1771a6ac86dcd99d3964e1be8601d7d): fix task lookup test
-* [keyremapping](https://github.com/runelite-extended/runelite/commit/0e8d377adfe688e5b9a98f5564ae2e2b4f46692f): fix race with sending messages and clearing chat input
-* [config service](https://github.com/runelite-extended/runelite/commit/730ad1c3c6b5389bf8e0be1c7e96bf8dbf340df1): return status based on whether set/unset were successful
-* [config service](https://github.com/runelite-extended/runelite/commit/4286c680f20a275ba44a93b2d221699770b24986): add test for parseJsonString
-* [config service](https://github.com/runelite-extended/runelite/commit/edfd52af23588922e5172d1c07c58dd62ed3f52a): validate config values
-* [xptracker](https://github.com/runelite-extended/runelite/commit/f300c541dc6a9da480abcaf24abffeb20bee4c6d): update lastXp after submitting xp gains
-* [xptracker](https://github.com/runelite-extended/runelite/commit/3b40f945a71927e2c75bd2da528f3ed25a2577b0): move initialization until after login
-* [xptracker](https://github.com/runelite-extended/runelite/commit/2ef1f29c13975ff45400ce3e1d4d0e5bcfe331ed): support xp gains when offline
-* [cml plugin](https://github.com/runelite-extended/runelite/commit/05ca96c3db49257f6adce9280f143966fc86cd08): fix request throttling
-* [http-service](https://github.com/runelite-extended/runelite/commit/277a3ccd35e55a3010c18bdb9c97d819418f3e06): use jndi provided mongo
-* [http-service](https://github.com/runelite-extended/runelite/commit/c6e24b832d2656e7bb80f0f442e79c7eeafc9eb4): remove inferred destroy method on mongo client bean
-* [osbuddy client](https://github.com/runelite-extended/runelite/commit/86f0c5ebd277dd743790a25a37126341de3b5f8f): update exchange summary location
-* [osbuddy client](https://github.com/runelite-extended/runelite/commit/d77134893a0a9b7e043790e1ccca97564ecc82f8): set UA to RuneLite
-* [overlay renderer](https://github.com/runelite-extended/runelite/commit/eb118c24dee7694535bca8ee0dd3d557738b2ca7): reduce graphics properties copying
-* [overlay renderer](https://github.com/runelite-extended/runelite/commit/fbb82a3b0a263efc6be27479617af47884079f6c): remove unnecessary color resetting
+* [slayer plugin](https://github.com/open-osrs/runelite/commit/715c7a26b903016f6dce0d7fe6bef9448051a615): validate !task name and location
+* [slayer plugin](https://github.com/open-osrs/runelite/commit/08fed6dba1771a6ac86dcd99d3964e1be8601d7d): fix task lookup test
+* [keyremapping](https://github.com/open-osrs/runelite/commit/0e8d377adfe688e5b9a98f5564ae2e2b4f46692f): fix race with sending messages and clearing chat input
+* [config service](https://github.com/open-osrs/runelite/commit/730ad1c3c6b5389bf8e0be1c7e96bf8dbf340df1): return status based on whether set/unset were successful
+* [config service](https://github.com/open-osrs/runelite/commit/4286c680f20a275ba44a93b2d221699770b24986): add test for parseJsonString
+* [config service](https://github.com/open-osrs/runelite/commit/edfd52af23588922e5172d1c07c58dd62ed3f52a): validate config values
+* [xptracker](https://github.com/open-osrs/runelite/commit/f300c541dc6a9da480abcaf24abffeb20bee4c6d): update lastXp after submitting xp gains
+* [xptracker](https://github.com/open-osrs/runelite/commit/3b40f945a71927e2c75bd2da528f3ed25a2577b0): move initialization until after login
+* [xptracker](https://github.com/open-osrs/runelite/commit/2ef1f29c13975ff45400ce3e1d4d0e5bcfe331ed): support xp gains when offline
+* [cml plugin](https://github.com/open-osrs/runelite/commit/05ca96c3db49257f6adce9280f143966fc86cd08): fix request throttling
+* [http-service](https://github.com/open-osrs/runelite/commit/277a3ccd35e55a3010c18bdb9c97d819418f3e06): use jndi provided mongo
+* [http-service](https://github.com/open-osrs/runelite/commit/c6e24b832d2656e7bb80f0f442e79c7eeafc9eb4): remove inferred destroy method on mongo client bean
+* [osbuddy client](https://github.com/open-osrs/runelite/commit/86f0c5ebd277dd743790a25a37126341de3b5f8f): update exchange summary location
+* [osbuddy client](https://github.com/open-osrs/runelite/commit/d77134893a0a9b7e043790e1ccca97564ecc82f8): set UA to RuneLite
+* [overlay renderer](https://github.com/open-osrs/runelite/commit/eb118c24dee7694535bca8ee0dd3d557738b2ca7): reduce graphics properties copying
+* [overlay renderer](https://github.com/open-osrs/runelite/commit/fbb82a3b0a263efc6be27479617af47884079f6c): remove unnecessary color resetting
 
 ##### [Alexsuperfly](https://github.com/Alexsuperfly):
-* [clue](https://github.com/runelite-extended/runelite/commit/a5a0e2645821691bb6e8496620a322754af127bc): add RUE GO anagram
-* [clue](https://github.com/runelite-extended/runelite/commit/068071997200bfb5d4fc91c1ad96169110141163): add Lady Trahaearn cryptic
-* [clue](https://github.com/runelite-extended/runelite/commit/94cbf355e0accceec4f93d55d1be6cafdedd58df): add elvish onions cryptic
-* [clue](https://github.com/runelite-extended/runelite/commit/fadb7420a561675287bc15e81f8ec6d1a9b52678): update bow near Lord Iorwerth emote
-* [clue](https://github.com/runelite-extended/runelite/commit/bd1158f96e76d265439e1261d24eeb9bef9a8b87): add bow in the Iorwerth camp emote
-* [clue](https://github.com/runelite-extended/runelite/commit/7213e1f83ebe4f397c1bd74409566c7d84a2f078): add beckon by crystalline maple trees emote
-* [skill calc](https://github.com/runelite-extended/runelite/commit/98fc599e15bcdc49b5dbabbe4d4cdcbab97b71ee): update prif course
-* [agility](https://github.com/runelite-extended/runelite/commit/896e2eaeca724641fabb87505095e385a9b629ec): update prif last obstacle exp
-* [agility](https://github.com/runelite-extended/runelite/commit/3a883f5c313bb2d5134225bdfe359129d4dd55bc): update prif whole course exp
-* [clue](https://github.com/runelite-extended/runelite/commit/f430381f089a7f2070f07a650d70d042799f54cc): update Falo crystal bow items
+* [clue](https://github.com/open-osrs/runelite/commit/a5a0e2645821691bb6e8496620a322754af127bc): add RUE GO anagram
+* [clue](https://github.com/open-osrs/runelite/commit/068071997200bfb5d4fc91c1ad96169110141163): add Lady Trahaearn cryptic
+* [clue](https://github.com/open-osrs/runelite/commit/94cbf355e0accceec4f93d55d1be6cafdedd58df): add elvish onions cryptic
+* [clue](https://github.com/open-osrs/runelite/commit/fadb7420a561675287bc15e81f8ec6d1a9b52678): update bow near Lord Iorwerth emote
+* [clue](https://github.com/open-osrs/runelite/commit/bd1158f96e76d265439e1261d24eeb9bef9a8b87): add bow in the Iorwerth camp emote
+* [clue](https://github.com/open-osrs/runelite/commit/7213e1f83ebe4f397c1bd74409566c7d84a2f078): add beckon by crystalline maple trees emote
+* [skill calc](https://github.com/open-osrs/runelite/commit/98fc599e15bcdc49b5dbabbe4d4cdcbab97b71ee): update prif course
+* [agility](https://github.com/open-osrs/runelite/commit/896e2eaeca724641fabb87505095e385a9b629ec): update prif last obstacle exp
+* [agility](https://github.com/open-osrs/runelite/commit/3a883f5c313bb2d5134225bdfe359129d4dd55bc): update prif whole course exp
+* [clue](https://github.com/open-osrs/runelite/commit/f430381f089a7f2070f07a650d70d042799f54cc): update Falo crystal bow items
 
 ##### [Hydrox6](https://github.com/Hydrox6):
-* [idle notifier](https://github.com/runelite-extended/runelite/commit/905240b50ed481c750a13def96d6f4d79a3c1015): notify when adding feathers or heads to shafts
-* [clues](https://github.com/runelite-extended/runelite/commit/02311b996e85ac95595a2448640c09fa5b1d0ae7): Move Item Requirement code from EmoteClue to its own sub-package
-* [clues](https://github.com/runelite-extended/runelite/commit/51c73798e425530cbc8a53d91c123f7d4430afe1): Add support for named AllRequirementsCollections
-* [clues](https://github.com/runelite-extended/runelite/commit/09b4517d316f03031262089ed63e162b4fc95b3d): Add support for Challenge Clues
-* [clues](https://github.com/runelite-extended/runelite/commit/724437480fc924c824deaa3ef01c4f2787771586): remove mis-categorised skill challenge
-* [item mapping](https://github.com/runelite-extended/runelite/commit/9a35a04ca0b255a0f84f5264c9c77e235715ff22): Add new crystal equipment IDs
-* [item prices](https://github.com/runelite-extended/runelite/commit/4b543d9dc2836cd9d7c5e3bbb608860e01b46414): show alch price while selecting item to alch
-* [item prices](https://github.com/runelite-extended/runelite/commit/effad44e17f1e0538da8472d24740f4a30eab8d7): show alch price when alching with Explorer's Ring interface
+* [idle notifier](https://github.com/open-osrs/runelite/commit/905240b50ed481c750a13def96d6f4d79a3c1015): notify when adding feathers or heads to shafts
+* [clues](https://github.com/open-osrs/runelite/commit/02311b996e85ac95595a2448640c09fa5b1d0ae7): Move Item Requirement code from EmoteClue to its own sub-package
+* [clues](https://github.com/open-osrs/runelite/commit/51c73798e425530cbc8a53d91c123f7d4430afe1): Add support for named AllRequirementsCollections
+* [clues](https://github.com/open-osrs/runelite/commit/09b4517d316f03031262089ed63e162b4fc95b3d): Add support for Challenge Clues
+* [clues](https://github.com/open-osrs/runelite/commit/724437480fc924c824deaa3ef01c4f2787771586): remove mis-categorised skill challenge
+* [item mapping](https://github.com/open-osrs/runelite/commit/9a35a04ca0b255a0f84f5264c9c77e235715ff22): Add new crystal equipment IDs
+* [item prices](https://github.com/open-osrs/runelite/commit/4b543d9dc2836cd9d7c5e3bbb608860e01b46414): show alch price while selecting item to alch
+* [item prices](https://github.com/open-osrs/runelite/commit/effad44e17f1e0538da8472d24740f4a30eab8d7): show alch price when alching with Explorer's Ring interface
 
 ##### [dekvall](https://github.com/dekvall):
-* [inventorygrid](https://github.com/runelite-extended/runelite/commit/2f15420a847404239954db6cd56012412875308a): Disable inventory grid if the dragged item is removed
-* [attack styles](https://github.com/runelite-extended/runelite/commit/688ab5064768da1d4b83da1862596879c9f536c6): fix NPE in overlay
-* [attack styles](https://github.com/runelite-extended/runelite/commit/e0dcb668da3d8a8443c7330e551b8e149e941beb): fix hide styles on weapon change
-* [loottracker](https://github.com/runelite-extended/runelite/commit/ef4c628068ec487b3bb47e1b0b1add56a20b5641): remove timestamp from LootTrackerRecord
-* [loottracker](https://github.com/runelite-extended/runelite/commit/1abadb0c9c36dddbd3ccdff83ec04eac4cac0c8c): fix order on client reload
-* [examine](https://github.com/runelite-extended/runelite/commit/c2111810d835921339526c23f6bf55df990c51d7): remove examine value for coins
-* [mining](https://github.com/runelite-extended/runelite/commit/ce4f90f6fa721b7013054277f6455868c1ad8c7c): fix respawn timers in misc and resource area
+* [inventorygrid](https://github.com/open-osrs/runelite/commit/2f15420a847404239954db6cd56012412875308a): Disable inventory grid if the dragged item is removed
+* [attack styles](https://github.com/open-osrs/runelite/commit/688ab5064768da1d4b83da1862596879c9f536c6): fix NPE in overlay
+* [attack styles](https://github.com/open-osrs/runelite/commit/e0dcb668da3d8a8443c7330e551b8e149e941beb): fix hide styles on weapon change
+* [loottracker](https://github.com/open-osrs/runelite/commit/ef4c628068ec487b3bb47e1b0b1add56a20b5641): remove timestamp from LootTrackerRecord
+* [loottracker](https://github.com/open-osrs/runelite/commit/1abadb0c9c36dddbd3ccdff83ec04eac4cac0c8c): fix order on client reload
+* [examine](https://github.com/open-osrs/runelite/commit/c2111810d835921339526c23f6bf55df990c51d7): remove examine value for coins
+* [mining](https://github.com/open-osrs/runelite/commit/ce4f90f6fa721b7013054277f6455868c1ad8c7c): fix respawn timers in misc and resource area
 
 ##### [trimbe](https://github.com/trimbe):
-* [gpu plugin](https://github.com/runelite-extended/runelite/commit/f3319df4a15098eb8017a118c641f51f0ae98503): fix camera effects used for drunkeness and fishing trawler
-* [runelite-api](https://github.com/runelite-extended/runelite/commit/e5ebd5a0513f771537a42041bf395bd71a10936d): remove devtools annotation and rename setSetting
-* [bank tags](https://github.com/runelite-extended/runelite/commit/4be0fc0e38566ddfc6b0739c83e892ecb8707e42): use setVarbit instead of setVarbitValue
-* [bank tags](https://github.com/runelite-extended/runelite/commit/a0aac8797130848b2e4491171624c3f06394a013): properly open saved tab
-* [clue](https://github.com/runelite-extended/runelite/commit/e0d1f408ccfe8cb5de99c3a28106f4a719f0e9df): center 'west of farming guild' location
-* [world map](https://github.com/runelite-extended/runelite/commit/76dfd6232ed3e22d8e8548278f24560d1053eb93): correct canvas bounds location and clip tooltips properly
+* [gpu plugin](https://github.com/open-osrs/runelite/commit/f3319df4a15098eb8017a118c641f51f0ae98503): fix camera effects used for drunkeness and fishing trawler
+* [runelite-api](https://github.com/open-osrs/runelite/commit/e5ebd5a0513f771537a42041bf395bd71a10936d): remove devtools annotation and rename setSetting
+* [bank tags](https://github.com/open-osrs/runelite/commit/4be0fc0e38566ddfc6b0739c83e892ecb8707e42): use setVarbit instead of setVarbitValue
+* [bank tags](https://github.com/open-osrs/runelite/commit/a0aac8797130848b2e4491171624c3f06394a013): properly open saved tab
+* [clue](https://github.com/open-osrs/runelite/commit/e0d1f408ccfe8cb5de99c3a28106f4a719f0e9df): center 'west of farming guild' location
+* [world map](https://github.com/open-osrs/runelite/commit/76dfd6232ed3e22d8e8548278f24560d1053eb93): correct canvas bounds location and clip tooltips properly
 
 ##### [abextm](https://github.com/abextm):
-* [ClanManager](https://github.com/runelite-extended/runelite/commit/0e8d377adfe688e5b9a98f5564ae2e2b4f46692f): handle startup with an empty cache
-* [runelite-api](https://github.com/runelite-extended/runelite/commit/a019d39361232aba563f5e74b387626470c90003): Annotate script ids with their argument counts
-* [runelite-api](https://github.com/runelite-extended/runelite/commit/4cec794a29096b97ddf6da42164a1a8d5ec29114): allow runScript to take a plain Object...
-* [runelite-client](https://github.com/runelite-extended/runelite/commit/56f7d09c923751d1b41dae225946bb53c229d2ef): Call scripts with the correct number of arguments
-* [runelite-client](https://github.com/runelite-extended/runelite/commit/944064b1b58823a0123edee250e20467e5c4ca2e): Make RuneLiteProperties fully static
-* [runelite-client](https://github.com/runelite-extended/runelite/commit/944064b1b58823a0123edee250e20467e5c4ca2e): Make RuneLiteProperties fully static
+* [ClanManager](https://github.com/open-osrs/runelite/commit/0e8d377adfe688e5b9a98f5564ae2e2b4f46692f): handle startup with an empty cache
+* [runelite-api](https://github.com/open-osrs/runelite/commit/a019d39361232aba563f5e74b387626470c90003): Annotate script ids with their argument counts
+* [runelite-api](https://github.com/open-osrs/runelite/commit/4cec794a29096b97ddf6da42164a1a8d5ec29114): allow runScript to take a plain Object...
+* [runelite-client](https://github.com/open-osrs/runelite/commit/56f7d09c923751d1b41dae225946bb53c229d2ef): Call scripts with the correct number of arguments
+* [runelite-client](https://github.com/open-osrs/runelite/commit/944064b1b58823a0123edee250e20467e5c4ca2e): Make RuneLiteProperties fully static
+* [runelite-client](https://github.com/open-osrs/runelite/commit/944064b1b58823a0123edee250e20467e5c4ca2e): Make RuneLiteProperties fully static
 
 ##### [TheStonedTurtle](https://github.com/TheStonedTurtle):
-* [menuentryswapper](https://github.com/runelite-extended/runelite/commit/f2cdc8a1d8913a25617913b1eebbe8805de98c80): Add volcanic mine entrance to swapQuick
-* [brokenondeathitem](https://github.com/runelite-extended/runelite/commit/742133e456daa2b5fa1f9fc57aac910fd51ac223): Fix death value by adding repair price
+* [menuentryswapper](https://github.com/open-osrs/runelite/commit/f2cdc8a1d8913a25617913b1eebbe8805de98c80): Add volcanic mine entrance to swapQuick
+* [brokenondeathitem](https://github.com/open-osrs/runelite/commit/742133e456daa2b5fa1f9fc57aac910fd51ac223): Fix death value by adding repair price
 
 ##### [dabolink](https://github.com/dabolink):
-* [achievmentdiary](https://github.com/runelite-extended/runelite/commit/139b97920ef0b3ee3b78016c9e7b91f372384e50): Update Ardougne Hard diary text
-* [loot tracker](https://github.com/runelite-extended/runelite/commit/345f07d20ff298fb814d568091bf4af880980448): add Kingdom of Miscellania
+* [achievmentdiary](https://github.com/open-osrs/runelite/commit/139b97920ef0b3ee3b78016c9e7b91f372384e50): Update Ardougne Hard diary text
+* [loot tracker](https://github.com/open-osrs/runelite/commit/345f07d20ff298fb814d568091bf4af880980448): add Kingdom of Miscellania
 
 ##### [Dava96](https://github.com/Dava96):
-* [skill calc](https://github.com/runelite-extended/runelite/commit/eb2d1d72597dc31bc0e5227853328ae306f2e64b): Add Dragon bolts
-* [ge](https://github.com/runelite-extended/runelite/commit/f71860fc6abd03950a36fced12af16bb7ff93a80): Add item limits for redwood and celastrus seeds/saplings
+* [skill calc](https://github.com/open-osrs/runelite/commit/eb2d1d72597dc31bc0e5227853328ae306f2e64b): Add Dragon bolts
+* [ge](https://github.com/open-osrs/runelite/commit/f71860fc6abd03950a36fced12af16bb7ff93a80): Add item limits for redwood and celastrus seeds/saplings
 
 ##### [tortuga69](https://github.com/tortuga69):
-* [grandexchange](https://github.com/runelite-extended/runelite/commit/4b239d26006efabbc8d2d380cd44f3713a9f5743): Add Forthos Dungeon item buy limits
-* [agility](https://github.com/runelite-extended/runelite/commit/21a188730b3829f2ce64d30bf49f10f3bf50efac): Add support for Trollweiss Mountain Cave agility shortcut
+* [grandexchange](https://github.com/open-osrs/runelite/commit/4b239d26006efabbc8d2d380cd44f3713a9f5743): Add Forthos Dungeon item buy limits
+* [agility](https://github.com/open-osrs/runelite/commit/21a188730b3829f2ce64d30bf49f10f3bf50efac): Add support for Trollweiss Mountain Cave agility shortcut
 
 ##### [Trevor159](https://github.com/Trevor159):
-* [clues](https://github.com/runelite-extended/runelite/commit/c7f8b6c6e1253937e0e8f3552c2c436248d9a60e): center northern blast mine dig location
-* [clues](https://github.com/runelite-extended/runelite/commit/535eef858397b979a2035bb6c4deecd818bcfbf9): center eastern part of piscatoris hunter area dig location
+* [clues](https://github.com/open-osrs/runelite/commit/c7f8b6c6e1253937e0e8f3552c2c436248d9a60e): center northern blast mine dig location
+* [clues](https://github.com/open-osrs/runelite/commit/535eef858397b979a2035bb6c4deecd818bcfbf9): center eastern part of piscatoris hunter area dig location
 
 ##### [deathbeam](https://github.com/deathbeam):
-* [overlayrenderer](https://github.com/runelite-extended/runelite/commit/480b4ad77304ea069af85b4384b5736993c3fb38): Snapshot all grahics2d properties in safeRender
+* [overlayrenderer](https://github.com/open-osrs/runelite/commit/480b4ad77304ea069af85b4384b5736993c3fb38): Snapshot all grahics2d properties in safeRender
 
 ##### [Darkkgreen](https://github.com/Darkkgreen):
-* [hunter](https://github.com/runelite-extended/runelite/commit/e0442fc03ade7ccadf1075b3eae5ae5ea301a5dd): Add support for ferrets
+* [hunter](https://github.com/open-osrs/runelite/commit/e0442fc03ade7ccadf1075b3eae5ae5ea301a5dd): Add support for ferrets
 
 ##### [xdesr](https://github.com/xdesr):
-* [item stats](https://github.com/runelite-extended/runelite/commit/502c7b6379604b3f9e31352229097b35832410cc): Add divine potions
+* [item stats](https://github.com/open-osrs/runelite/commit/502c7b6379604b3f9e31352229097b35832410cc): Add divine potions
 
 ##### [Serpa88](https://github.com/Serpa88):
-* [Loot Tracker](https://github.com/runelite-extended/runelite/commit/1082b1b86337cdeb100a1095608b6e67ebd753b1): Allow loot boxes to be collapsed
+* [Loot Tracker](https://github.com/open-osrs/runelite/commit/1082b1b86337cdeb100a1095608b6e67ebd753b1): Allow loot boxes to be collapsed
 
 ##### [Bjdufre1](https://github.com/Bjdufre1):
-* [skill calc](https://github.com/runelite-extended/runelite/commit/e9fae0dbe431aa898d31944fe6901e108e21198c): Add four dose stamina to herblore calculator
+* [skill calc](https://github.com/open-osrs/runelite/commit/e9fae0dbe431aa898d31944fe6901e108e21198c): Add four dose stamina to herblore calculator
 
 ##### [charredgrass](https://github.com/charredgrass):
-* [discord](https://github.com/runelite-extended/runelite/commit/26855079fe3839164d8b20fb3c555c0f20bbd9f1): Fix spelling errors in Discord status locations
+* [discord](https://github.com/open-osrs/runelite/commit/26855079fe3839164d8b20fb3c555c0f20bbd9f1): Fix spelling errors in Discord status locations
 
 ##### [Toocanzs](https://github.com/Toocanzs):
-* [gpu](https://github.com/runelite-extended/runelite/commit/bb4ef3298ef219023310b45c260b36b1635c820c): fix MSAA white pixels
+* [gpu](https://github.com/open-osrs/runelite/commit/bb4ef3298ef219023310b45c260b36b1635c820c): fix MSAA white pixels
 
 ##### [Nightfirecat](https://github.com/Nightfirecat):
-* [gpu](https://github.com/runelite-extended/runelite/commit/1c6333410ac3f9c6f97d7a40fc0b0bbe599d5e5e): Center level 5 wilderness location
+* [gpu](https://github.com/open-osrs/runelite/commit/1c6333410ac3f9c6f97d7a40fc0b0bbe599d5e5e): Center level 5 wilderness location
 
 ##### [DylPickle96](https://github.com/DylPickle96):
-* [clue](https://github.com/runelite-extended/runelite/commit/3e277a503930dd6c05cd1309ac80b6fd5171589d): Add the new General Hining cryptic clue
+* [clue](https://github.com/open-osrs/runelite/commit/3e277a503930dd6c05cd1309ac80b6fd5171589d): Add the new General Hining cryptic clue
 
 ##### [nateisonfire](https://github.com/nateisonfire):
-* [slayer](https://github.com/runelite-extended/runelite/commit/2af3b47455eb47bc64b089c9ae7cf2228789cc68): add Sarachnis task
+* [slayer](https://github.com/open-osrs/runelite/commit/2af3b47455eb47bc64b089c9ae7cf2228789cc68): add Sarachnis task
 
 ##### [Bonsaigin](https://github.com/Bonsaigin):
-* [clue](https://github.com/runelite-extended/runelite/commit/e18acd6de9277b98ca3a4f7d494659b9b68af91c): update Monk camp clue location
+* [clue](https://github.com/open-osrs/runelite/commit/e18acd6de9277b98ca3a4f7d494659b9b68af91c): update Monk camp clue location
 
 ##### [Krysaczek](https://github.com/Krysaczek):
-* [agility](https://github.com/runelite-extended/runelite/commit/d1193a78ff4eb139cb00a4f1a2e2974f4b1969ef): add Isafdar tripwire
+* [agility](https://github.com/open-osrs/runelite/commit/d1193a78ff4eb139cb00a4f1a2e2974f4b1969ef): add Isafdar tripwire
 
 ##### [raiyni](https://github.com/raiyni):
-* [colorpicker](https://github.com/runelite-extended/runelite/commit/ac5b2ff82a8509da825e7e5341a17d562c93b7a7): force hex color to update on window close
+* [colorpicker](https://github.com/open-osrs/runelite/commit/ac5b2ff82a8509da825e7e5341a17d562c93b7a7): force hex color to update on window close

--- a/src/assets/posts/openosrs-update-2.1.3.1.md
+++ b/src/assets/posts/openosrs-update-2.1.3.1.md
@@ -1,17 +1,17 @@
 ## OpenOSRS 2.1.3.1
 
 ##### [Ganom](https://github.com/Ganom)
-* [menuentryswapper](https://github.com/runelite-extended/runelite/commit/70c162019e290cdc929947676878655d4fe6da2c): various menu fixes
-* [menuentryswapper](https://github.com/runelite-extended/runelite/commit/df7139eee9c4be2823eda68cf53fe00b160117a5): fix swap removal for "collect-notes"
-* [menuentryswapper](https://github.com/runelite-extended/runelite/commit/c5934045d5a02a6aa41e4c1f8960b688ef1ce497): set priority for climb up and down.
-* [menuentryswapper](https://github.com/runelite-extended/runelite/commit/103d06c60ce3cc673a14798c274014344abc1b1f): add construction enum.
-* [menuentryswapper](https://github.com/runelite-extended/runelite/commit/bc4168c4002b3264f0878ed17af829768c40c79a): fix "use" being over prioritized.
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1368/commits/d790b0d31edf4105fbde8be415c9a39bf8cc7e2d): various changes and fixes.
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1368/commits/731039f37f780a9b6fb5429f7ce5de7499e5e3e4): fix "rub" and "teleport" on inventory items.
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1368/commits/0a5ce3d2b9454094e4989bb4e5aed3806a7c265b): fix "reset" on box traps
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1368/commits/b068def2e1c78015c5d0f66b65be9b79e3cd5353): fix use bones.
-* [menuentryswapper](https://github.com/runelite-extended/runelite/commit/3ebed10e16a6562ea5cc2bafdafd100175e55017): fix certain entries not being removed, and remove strict default on BankComparableEntry.
-* [menuentryswapper](https://github.com/runelite-extended/runelite/commit/456f062db752b6b8b894e882c4bd6d9b5ac804fb): finally fix "collect" in grand exchange window.
+* [menuentryswapper](https://github.com/open-osrs/runelite/commit/70c162019e290cdc929947676878655d4fe6da2c): various menu fixes
+* [menuentryswapper](https://github.com/open-osrs/runelite/commit/df7139eee9c4be2823eda68cf53fe00b160117a5): fix swap removal for "collect-notes"
+* [menuentryswapper](https://github.com/open-osrs/runelite/commit/c5934045d5a02a6aa41e4c1f8960b688ef1ce497): set priority for climb up and down.
+* [menuentryswapper](https://github.com/open-osrs/runelite/commit/103d06c60ce3cc673a14798c274014344abc1b1f): add construction enum.
+* [menuentryswapper](https://github.com/open-osrs/runelite/commit/bc4168c4002b3264f0878ed17af829768c40c79a): fix "use" being over prioritized.
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1368/commits/d790b0d31edf4105fbde8be415c9a39bf8cc7e2d): various changes and fixes.
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1368/commits/731039f37f780a9b6fb5429f7ce5de7499e5e3e4): fix "rub" and "teleport" on inventory items.
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1368/commits/0a5ce3d2b9454094e4989bb4e5aed3806a7c265b): fix "reset" on box traps
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1368/commits/b068def2e1c78015c5d0f66b65be9b79e3cd5353): fix use bones.
+* [menuentryswapper](https://github.com/open-osrs/runelite/commit/3ebed10e16a6562ea5cc2bafdafd100175e55017): fix certain entries not being removed, and remove strict default on BankComparableEntry.
+* [menuentryswapper](https://github.com/open-osrs/runelite/commit/456f062db752b6b8b894e882c4bd6d9b5ac804fb): finally fix "collect" in grand exchange window.
 
 ##### [Netami1](https://github.com/Netami1)
-* [runecraftplugin](https://github.com/runelite-extended/runelite/commit/3232b74f27e6eb8febc738cf0b9c1566584b4ece): add length check
+* [runecraftplugin](https://github.com/open-osrs/runelite/commit/3232b74f27e6eb8febc738cf0b9c1566584b4ece): add length check

--- a/src/assets/posts/openosrs-update-2.1.4.0.md
+++ b/src/assets/posts/openosrs-update-2.1.4.0.md
@@ -5,57 +5,57 @@
 ## OpenOSRS 2.1.4.0
 
 ##### [Ganom](https://github.com/Ganom)
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1391/commits/d050a6eceea598ad41abb6c6d68bd186c6e5871c): remove shift click customisation for a better alternative.
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1391/commits/f42abad096602bc3dc83cc28295ca9f10edc28c7): add proper syntax validation, and convert to priority entries.
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1391/commits/136d849ca01f5a9a34ad92f49087443e3332bf80): finalize
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1391/commits/73fd6d0794f07d77c7f9826eaeea5cdeb77e29cd): remove redundant splitter.
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1391/commits/f40db024bc22787f43a86108816a0082d01ba8bd): fix camelCase on Lavas
-* [runecraft](https://github.com/runelite-extended/runelite/pull/1391/commits/556ba10fb30ec03591da8815901f86cd8c59ed66): disable lavas by default
-* [runecraft](https://github.com/runelite-extended/runelite/commit/904943440f90704607d222ca447f6666fa6b9446): fix pouch strictness
-* [menuentryswapper](https://github.com/runelite-extended/runelite/commit/5cfd968676f6e621105172487422115b39c6e7cb): add "Prioritize Entry" config option.
-* [discordclient](https://github.com/runelite-extended/runelite/commit/aa4b505fe291909646d70ce413ac4a6f84bf0fa8): remove build.default, as it was causing NPEs
-* [playerscouter](https://github.com/runelite-extended/runelite/commit/6e5bebe734acf1735f2bca39ef020b19c383c020): fix value mapping.
-* [menumanager](https://github.com/runelite-extended/runelite/commit/8abdd56f9e367ee84f74ceab2db54a65b1f3d2f6): true band aid fix
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1391/commits/d050a6eceea598ad41abb6c6d68bd186c6e5871c): remove shift click customisation for a better alternative.
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1391/commits/f42abad096602bc3dc83cc28295ca9f10edc28c7): add proper syntax validation, and convert to priority entries.
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1391/commits/136d849ca01f5a9a34ad92f49087443e3332bf80): finalize
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1391/commits/73fd6d0794f07d77c7f9826eaeea5cdeb77e29cd): remove redundant splitter.
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1391/commits/f40db024bc22787f43a86108816a0082d01ba8bd): fix camelCase on Lavas
+* [runecraft](https://github.com/open-osrs/runelite/pull/1391/commits/556ba10fb30ec03591da8815901f86cd8c59ed66): disable lavas by default
+* [runecraft](https://github.com/open-osrs/runelite/commit/904943440f90704607d222ca447f6666fa6b9446): fix pouch strictness
+* [menuentryswapper](https://github.com/open-osrs/runelite/commit/5cfd968676f6e621105172487422115b39c6e7cb): add "Prioritize Entry" config option.
+* [discordclient](https://github.com/open-osrs/runelite/commit/aa4b505fe291909646d70ce413ac4a6f84bf0fa8): remove build.default, as it was causing NPEs
+* [playerscouter](https://github.com/open-osrs/runelite/commit/6e5bebe734acf1735f2bca39ef020b19c383c020): fix value mapping.
+* [menumanager](https://github.com/open-osrs/runelite/commit/8abdd56f9e367ee84f74ceab2db54a65b1f3d2f6): true band aid fix
 
 ##### [Owain](https://github.com/Owain94)
-* [infopanel](https://github.com/runelite-extended/runelite/commit/23710f3f4a8e558f315525d9c555b374d2456dd0): Fix plus version font
-* [raids/profiles panel](https://github.com/runelite-extended/runelite/commit/882091e1423a57bf54e387ca94c0be7ab7829ff4): Fix plus version font
-* [raids](https://github.com/runelite-extended/runelite/commit/a868adfc6c9d9e5b2f494da5d8bc74afa1b6820c): Update reload instance button to send a gamestate
-* [menuentryswapper](https://github.com/runelite-extended/runelite/pull/1391/commits/878d1acf0a5ff2bfee762a4cc2d80a5d5e02346f): Migrate old swaps to the new format
-* [profilepanel](https://github.com/runelite-extended/runelite/commit/f3916c8cb2436f0afc9b869f27702f78e8e7b7a4): Don't remove the login box when the password is incorrect
-* [menuentryswapper](https://github.com/runelite-extended/runelite/commit/1c5bd185cd6922913df2faf563c4662365197ea9): Fix dupe keys when migrating (also filter walk here and cancel for now)
-* [menuentryswapper](https://github.com/runelite-extended/runelite/commit/083c0f45423127ca1ed74d01c2811a89408cde84): Don't add swaps without a target
-* [mixins](https://github.com/runelite-extended/runelite/commit/2d80de239d03528100729092623131ac5ed8804b): Add setGameState(Gamestate)
-* [client](https://github.com/runelite-extended/runelite/commit/0a20ef601d37fb8725bfb1180f87136e40acca25): Add database
+* [infopanel](https://github.com/open-osrs/runelite/commit/23710f3f4a8e558f315525d9c555b374d2456dd0): Fix plus version font
+* [raids/profiles panel](https://github.com/open-osrs/runelite/commit/882091e1423a57bf54e387ca94c0be7ab7829ff4): Fix plus version font
+* [raids](https://github.com/open-osrs/runelite/commit/a868adfc6c9d9e5b2f494da5d8bc74afa1b6820c): Update reload instance button to send a gamestate
+* [menuentryswapper](https://github.com/open-osrs/runelite/pull/1391/commits/878d1acf0a5ff2bfee762a4cc2d80a5d5e02346f): Migrate old swaps to the new format
+* [profilepanel](https://github.com/open-osrs/runelite/commit/f3916c8cb2436f0afc9b869f27702f78e8e7b7a4): Don't remove the login box when the password is incorrect
+* [menuentryswapper](https://github.com/open-osrs/runelite/commit/1c5bd185cd6922913df2faf563c4662365197ea9): Fix dupe keys when migrating (also filter walk here and cancel for now)
+* [menuentryswapper](https://github.com/open-osrs/runelite/commit/083c0f45423127ca1ed74d01c2811a89408cde84): Don't add swaps without a target
+* [mixins](https://github.com/open-osrs/runelite/commit/2d80de239d03528100729092623131ac5ed8804b): Add setGameState(Gamestate)
+* [client](https://github.com/open-osrs/runelite/commit/0a20ef601d37fb8725bfb1180f87136e40acca25): Add database
 
 ##### [xKylee](https://github.com/xKylee)
-* [inferno](https://github.com/runelite-extended/runelite/commit/6bff3e38f8e607a783566a54395faef5274a78c4): fix plugin start-up error.
-* [reminders](https://github.com/runelite-extended/runelite/commit/e803fad01461d1b96ecd364717d4b2c8fe0d600b): added reminders plugin
-* [whalewatchers](https://github.com/runelite-extended/runelite/commit/e31333eb469dd0a25423910683d5ecb8168cbe85): pneck break warning sound
-* [Playerscouter](https://github.com/runelite-extended/runelite/commit/4b4af0fa2b3d56355ca854893ba150191c85df56): add combat bracket
+* [inferno](https://github.com/open-osrs/runelite/commit/6bff3e38f8e607a783566a54395faef5274a78c4): fix plugin start-up error.
+* [reminders](https://github.com/open-osrs/runelite/commit/e803fad01461d1b96ecd364717d4b2c8fe0d600b): added reminders plugin
+* [whalewatchers](https://github.com/open-osrs/runelite/commit/e31333eb469dd0a25423910683d5ecb8168cbe85): pneck break warning sound
+* [Playerscouter](https://github.com/open-osrs/runelite/commit/4b4af0fa2b3d56355ca854893ba150191c85df56): add combat bracket
 
 ##### [formatme](https://github.com/f0rmatme) / Alexander van spauwen
-* [chatboxperformance](https://github.com/runelite-extended/runelite/pull/1396/commits/d36de1353fee0e7776d204ff97be2777c1ddf1c4): Toggle chatbox gradient
+* [chatboxperformance](https://github.com/open-osrs/runelite/pull/1396/commits/d36de1353fee0e7776d204ff97be2777c1ddf1c4): Toggle chatbox gradient
 
 ##### [Lucwousin](https://github.com/Lucwousin)
-* [menuaction](https://github.com/runelite-extended/runelite/pull/1344/commits/091467145c435e3050f0437408daee1834ad5385): MenuOpcode merge
-* [rs-client](https://github.com/runelite-extended/runelite/pull/1344/commits/7ad497fc9aeb01ab5e859f1b2b0b86a50ef9714f): refactoring
-* [spellbook](https://github.com/runelite-extended/runelite/commit/b57a682ce7ba769f22be1062f93f2beb59eec091): bugfixes/improvements
+* [menuaction](https://github.com/open-osrs/runelite/pull/1344/commits/091467145c435e3050f0437408daee1834ad5385): MenuOpcode merge
+* [rs-client](https://github.com/open-osrs/runelite/pull/1344/commits/7ad497fc9aeb01ab5e859f1b2b0b86a50ef9714f): refactoring
+* [spellbook](https://github.com/open-osrs/runelite/commit/b57a682ce7ba769f22be1062f93f2beb59eec091): bugfixes/improvements
 
 ##### [ThatGamerBlue](https://github.com/ThatGamerBlue)
-* [http-api](https://github.com/runelite-extended/runelite/commit/a27b355fdd5dfc6541c7dc8a9540cf7dbbadfe69): change useragent, remove unused methods, reordering
-* [chatmessagemanager](https://github.com/runelite-extended/runelite/commit/345f01645ac3e5a2c7d58a1ba362f2e26f23a9ef): add null check guard case for chat message manager
+* [http-api](https://github.com/open-osrs/runelite/commit/a27b355fdd5dfc6541c7dc8a9540cf7dbbadfe69): change useragent, remove unused methods, reordering
+* [chatmessagemanager](https://github.com/open-osrs/runelite/commit/345f01645ac3e5a2c7d58a1ba362f2e26f23a9ef): add null check guard case for chat message manager
 
 ##### [Damhan](https://github.com/Damhan)
-* [clanchatplugin](https://github.com/runelite-extended/runelite/commit/491c8b12fb03b089a944ed0fe4a54b56ad283153): fix UnsupportedOperationException
-* [idlenotifier](https://github.com/runelite-extended/runelite/commit/6280bcbba3d7d77bf3f2f0b8c56e273ba0417f10): adds notification to wildy resource door
+* [clanchatplugin](https://github.com/open-osrs/runelite/commit/491c8b12fb03b089a944ed0fe4a54b56ad283153): fix UnsupportedOperationException
+* [idlenotifier](https://github.com/open-osrs/runelite/commit/6280bcbba3d7d77bf3f2f0b8c56e273ba0417f10): adds notification to wildy resource door
 
 ##### [Lohouse](https://github.com/Lohouse)
-* [inferno](https://github.com/runelite-extended/runelite/commit/3946471568ac3b4adcbb028146357f542621b8c6): add multiple jad support, prayer indicator, healer indicator
+* [inferno](https://github.com/open-osrs/runelite/commit/3946471568ac3b4adcbb028146357f542621b8c6): add multiple jad support, prayer indicator, healer indicator
 
 ##### [SRLJustin](https://github.com/SRLJustin)
-* [slayermusiq](https://github.com/runelite-extended/runelite/commit/5745216fc8a24c9124892438f281507f55016fd4): added song of the elves & miniquests
+* [slayermusiq](https://github.com/open-osrs/runelite/commit/5745216fc8a24c9124892438f281507f55016fd4): added song of the elves & miniquests
 
 ##### [MattFaris](https://github.com/MattFaris)
-* [cannonplugin](https://github.com/runelite-extended/runelite/commit/385c56512aba5fee3f95bb6b0ba851de5080d353): Fix issue with cannon spots not displaying
+* [cannonplugin](https://github.com/open-osrs/runelite/commit/385c56512aba5fee3f95bb6b0ba851de5080d353): Fix issue with cannon spots not displaying
 

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <title>RuneLite Plus</title>
+  <title>OpenOSRS</title>
   <base href="/">
 
   <link rel="preconnect" href="https://ajax.googleapis.com" />


### PR DESCRIPTION
The following haven't been changed and need to be (or not, who knows):
* `  private db = new NgxIndexedDB('runelite-plus', 1);` Line 23 of `src/app/services/github.service.ts`, because I'm too lazy to figure out if this would impact anything
* Greenkeeper badge, because idk how it works
* Netlify badge, same reason